### PR TITLE
Add bonus for connected pieces

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -165,6 +165,7 @@ namespace {
   // Assorted bonuses and penalties
   const Score BishopPawns       = S(  8, 12);
   const Score CloseEnemies      = S(  7,  0);
+  const Score Connectivity      = S(  2,  2);
   const Score Hanging           = S( 52, 30);
   const Score HinderPassedPawn  = S(  8,  1);
   const Score KnightOnQueen     = S( 21, 11);
@@ -598,6 +599,10 @@ namespace {
 
         score += SliderOnQueen * popcount(b & safeThreats & attackedBy2[Us]);
     }
+
+    // Connectivity: ensure that knights, bishops, rooks, and queens are protected
+    b = (pos.pieces(Us) ^ pos.pieces(Us, PAWN, KING)) & attackedBy[Us][ALL_PIECES];
+    score += Connectivity * popcount(b);
 
     if (T)
         Trace::add(THREAT, Us, score);


### PR DESCRIPTION
"Loose pieces drop, in blitz keep everything protected"

Adding a small S(2,2) bonus for knights, bishops, rooks, and
queens that are "connected" to each other (in the sense that
they are under attack by our own pieces) apparently is a good
thing. It probably helps the pieces work together a bit better.

STC
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 12317 W: 2655 L: 2467 D: 7195
http://tests.stockfishchess.org/tests/view/5aa2d86b0ebc590297cb6474

LTC
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 35725 W: 5516 L: 5263 D: 24946
http://tests.stockfishchess.org/tests/view/5aa2fc6f0ebc590297cb64a8

How to continue from there (by Stefan Geschwentner)?

• First we should identify all other eval terms which have an overlap
  with new connectivity bonus (like the outpost bonus). A simple way
  would be subtract the connectivity bonus from them and look if this
  better, or use a SPSA session for these terms.

• Tuning Connectivity himself with SPSA seems not so promising because
  of the small range which is useful. Here manual testing changes of
  Connectivity like +-1 seems better.

• The eg value is more important because in endgame the position gets
  more open and so attacks on pieces are easier. Another important point
  is that when defending/fortress-like positions each defending piece
  needs a protection, otherwise attacks on them can break defense.

Closes https://github.com/official-stockfish/Stockfish/pull/1474

Bench: 5318575