### PR TITLE
Check the clock every 1024 nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1497,7 +1497,7 @@ void MainThread::check_time() {
       return;
 
   // When using nodes, ensure checking rate is not lower than 0.1% of nodes
-  callsCnt = Limits.nodes ? std::min(4096, int(Limits.nodes / 1024)) : 4096;
+  callsCnt = Limits.nodes ? std::min(1024, int(Limits.nodes / 1024)) : 1024;
 
   static TimePoint lastInfoTime = now();
 


### PR DESCRIPTION
This patch checks the clock every 1024, instead of 4096 in current master.

This is a step towards a solution to alleviate the problem reported by
Gian-Carlo Pascutto in pull request #1471, about a situation where SF
would sometimes lose on time in endgames at time control 1min+1sec when
using Syzygy EGTB on a spinning drive.

We made four tests called "Estimate the Elo cost of calling now() every
N nodes", with N in {256,1024} and time control in {STC,LTC}. Each test
was 40000 games with auto-purge off, against master branch.

http://tests.stockfishchess.org/tests/view/5aa4f37c0ebc59029780ff2d
http://tests.stockfishchess.org/tests/view/5aa4f3080ebc59029780ff2b
http://tests.stockfishchess.org/tests/view/5aa5cbb50ebc59029780ffce
http://tests.stockfishchess.org/tests/view/5aa5cb730ebc59029780ffcc

Here is a summary of the results (speed-up and Elo gain against master):

|   Time   |       N=256       |      N=1024      |
|:--------:|:-----------------:|:----------------:|
| Speed-up |    0.1% slower    |   0.2% faster    |
|   STC    |  -0.33 +-2.2 Elo  |  1.33 +-2.2 Elo  |
|   LTC    |   1.08 +-2.3 Elo  |  2.34 +-2.2 Elo  |

Based on these results, we tested N=1024 as a non-regression against
master at LTC:

LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 80746 W: 12430 L: 12399 D: 55917
http://tests.stockfishchess.org/tests/view/5aa7ba660ebc590297810116

Closes https://github.com/official-stockfish/Stockfish/pull/1482

No functional change.